### PR TITLE
added resource definitions for chrome and router

### DIFF
--- a/charts/selenium-grid/templates/chrome-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-deployment.yaml
@@ -48,4 +48,6 @@ spec:
           ports:
             - containerPort: {{ .Values.distributor.distributorPort }}
               protocol: TCP
+          resources:
+{{ toYaml .Values.chrome.resources | indent 12 }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-deployment.yaml
@@ -49,5 +49,5 @@ spec:
             - containerPort: {{ .Values.distributor.distributorPort }}
               protocol: TCP
           resources:
-{{ toYaml .Values.chrome.resources | indent 12 }}
+{{ toYaml .Values.chrome.resources | nindent 12 }}
 {{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -37,3 +37,5 @@ spec:
           ports:
             - containerPort: {{ .Values.router.port }}
               protocol: TCP
+          resources:
+{{ toYaml .Values.router.resources | indent 12 }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -38,4 +38,4 @@ spec:
             - containerPort: {{ .Values.router.port }}
               protocol: TCP
           resources:
-{{ toYaml .Values.router.resources | indent 12 }}
+{{ toYaml .Values.router.resources | nindent 12 }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -6,6 +6,15 @@ router:
   serviceType: "ClusterIP"
   loadBalancerSourceRanges: []
 
+  # -- Configure router resource requests/limits
+  resources:
+    requests:
+      # memory: "512Mi"
+      # cpu: "0.5"
+    limits:
+      # memory: "1Gi"
+      # cpu: "1"
+
   # -- Define router service port
   port: 4444
   # -- Define router service port name
@@ -47,6 +56,15 @@ chrome:
   screenDepth:
   # -- (int) Chrome node screen dpi configuration
   screenDpi:
+
+  # -- Configure chrome node resource requests/limits
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "1"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
 
   # -- Chrome node vnc port
   vncPort: 6900


### PR DESCRIPTION
resource configuration added for chrome and router
chrome default values set according to https://github.com/SeleniumHQ/docker-selenium#increasing-session-concurrency-per-container

Closes #18 